### PR TITLE
fix missing "tx" key when creating BMAP for anon posts

### DIFF
--- a/app/components/actions/anon-reply-server-action.tsx
+++ b/app/components/actions/anon-reply-server-action.tsx
@@ -62,6 +62,7 @@ export const postAnonReply = async (postTxid: string, note: string, amountToLock
               "post",
               "context",
               "tx",
+              "tx",
               postTxid,
               "paymail",
               "anon",


### PR DESCRIPTION
this commit makes the BMAP creation be the same shape for logged in and anon users and should fix the the garbled bmaps showing in block explorers (eg [1])

looks like in commit 9473ed99 the second "tx" key got dropped when creating the BMAP for a reply.

[1]: https://whatsonchain.com/tx/bad90ae561d5787ef7dbfab0564db7b44fa20cb7387fbabbac10974ba47b94f9