### PR TITLE
upgrade next@14.1.1-canary.4 to 14.1.1-canary.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "hexoid": "^1.0.0",
         "image-resize-compress": "^1.1.0",
         "isomorphic-dompurify": "^1.8.0",
-        "next": "^14.1.1-canary.4",
+        "next": "^14.1.1-canary.17",
         "next13-progressbar": "^1.1.3",
         "panda-wallet-provider": "^2.3.1",
         "plaiceholder": "^3.0.0",
@@ -1075,9 +1075,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.1-canary.4.tgz",
-      "integrity": "sha512-/01rNwdJDYwWZmb9x1Coz/ANIfZIoo6/RKNh2TIoYJQ0f/EI30t1z774TrMx85Fi7Hp4aDRViiYVDuWkAVi+KA=="
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.1-canary.17.tgz",
+      "integrity": "sha512-djnSCCQryoNi2L048SclC3azJOrSR5AeuN7cR4qlZYIFg5zOPe+TRXJbvQgCiKf9RGxlduBnTTRcEfrC0jvKGw=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.1.0",
@@ -1131,9 +1131,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.1-canary.4.tgz",
-      "integrity": "sha512-UUAE8itto/4gT7HF8rL0pg5qPOqXDhqk67FYaOc8RwlIB0BZP9t2mABuLaFmX76ZHsNrOLbo3mYdYVWYm2Mtug==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.1-canary.17.tgz",
+      "integrity": "sha512-VSyfaRwwqr7aery2jTm7AlcjbDXTnwV7w5ugjmr7Nq7nNxG2COkk7VmZI19qeWVWK0JxHbBjdTQX/Xxb019ZsA==",
       "cpu": [
         "arm64"
       ],
@@ -1146,9 +1146,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.1-canary.4.tgz",
-      "integrity": "sha512-bsxU77hScnioL5d5/ebjH+fDkxkcZjKyPtN1bVDalqe9FvqKarrakjVcjFo9ist1xdUkKdAq6bBhUJ1BkMq2oQ==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.1-canary.17.tgz",
+      "integrity": "sha512-Et5VG0JllbDzzMxhxYjyOSNhhcVk+8YJOr+BRcEQFP0Kavys/AlywWlVlKkpsXrJ57YZ4P05e1Qlc504oEecHA==",
       "cpu": [
         "x64"
       ],
@@ -1161,9 +1161,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.1-canary.4.tgz",
-      "integrity": "sha512-4h60BqjbwdOFN3W3rX5xpV9DFTH6iCV5vec2Ed92ZjggdqXJ1eziW4RRYx/Tvj7t0RgRilSvEeSm2fKL+Hqb1A==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.1-canary.17.tgz",
+      "integrity": "sha512-2z+Bq7k2NabF+frqXbECJ5RhPU05M+Jx+NtfeoOL0hxmmsU+uxU3kqecR8EqZHOlCFfjSIwXd6PGO+lRlzHVIg==",
       "cpu": [
         "arm64"
       ],
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.1-canary.4.tgz",
-      "integrity": "sha512-PJwv3CTSuWdBiDb6w4RCm4s5ls3D84Up+N+68hjDzncd8aLbvC3GFJY1MjZwR4TOmE76j8pGeHsr2quJhxPKgA==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.1-canary.17.tgz",
+      "integrity": "sha512-h1L7IH9cXqRPGjZ5nkIeZhAcU6Y1n+ZIRSjbup6kBBFBIs/Z0uAFNjWfX6lcxd5kPNCPLrIabhAKjJHwo/aEaw==",
       "cpu": [
         "arm64"
       ],
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.1-canary.4.tgz",
-      "integrity": "sha512-TOJ2An1AQWKHgqrkVtm3rU5v6urka8wON8mbnBHhU9VPqicSrnFaOL8z8HgU6g6wQncG0nXtaokYkn3EHKcZKw==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.1-canary.17.tgz",
+      "integrity": "sha512-7Q39fu8g5EcRWxRK7Zc3FEWsAlVxqct/eNykuO7J/15XMGvDfEKkI8DUs77cqVaLa/qALsTihXCU7Mbl+wxLKg==",
       "cpu": [
         "x64"
       ],
@@ -1206,9 +1206,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.1-canary.4.tgz",
-      "integrity": "sha512-Vz3/OqC4L0ZkbStlPjadMS0rG3EasHUikKZ9u2KZpDXza+/rHC+lppsEjWE949itsYTHs9bRScmRaHvw7/i8wA==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.1-canary.17.tgz",
+      "integrity": "sha512-9cnToNkGh8da8Z3KgiqB+aFuRX0eMzK7wIWBnAFCIQD3U6USf3T5BUTFqD4JS5X1+IUiFb5dWlFX0tPZVdIkTw==",
       "cpu": [
         "x64"
       ],
@@ -1221,9 +1221,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.1-canary.4.tgz",
-      "integrity": "sha512-fY+Bpd/Byg9e9CQSh8gmcJIqueQ8Z4yHelvp1JjrTnKHjWV0M3x8J4uPfiL/P5YXDeQowIc7ezneK6+dpo+bEQ==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.1-canary.17.tgz",
+      "integrity": "sha512-a/dL3tkGNhsi9Ipi5oR9BJ5IsmeAbgLuOJf0P7CTyGhesNz+6jyqNLc/r3backYzUETo8G2qb1M3VVly9767Lg==",
       "cpu": [
         "arm64"
       ],
@@ -1236,9 +1236,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.1-canary.4.tgz",
-      "integrity": "sha512-woi/uOkWjDdNjpZfO5qI7idcR9cx0rp8CvxH+llW2gkiGHV9IfDh5z5G3G3yeB7HEJY46pjzHsvqwarTmY2oMQ==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.1-canary.17.tgz",
+      "integrity": "sha512-hcWdZOycU/8CwEQzuGRXgbWRlsQ+Zmxgp2foMxvUfnihIch7UlNxCJD6RKDOAG1KBwNGvoIQKREALO7ya30VOA==",
       "cpu": [
         "ia32"
       ],
@@ -1251,9 +1251,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.1-canary.4.tgz",
-      "integrity": "sha512-NVP2FFliWNafaJ0ZOp4aQF0jTLIV69XdS3DjJn2/iLPMtSw3IAJCHapebCUM/TVXy8g21hpVxgCOBDj5hgljJw==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.1-canary.17.tgz",
+      "integrity": "sha512-9WYiEF3TWHBVLY3F/6JMOtZVxNe2drPc96Jk6njFtBUR/ds08TBR2n7Llm2YVcEunOV8ybgIo+uX8Kv9Pqk+UQ==",
       "cpu": [
         "x64"
       ],
@@ -9953,11 +9953,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "14.1.1-canary.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.1.1-canary.4.tgz",
-      "integrity": "sha512-h+BYp5T9oJwdajP0ROeAVrSxzccT48zeEjjxlbYs40lSq1alQNPcNsSLPXZ0id/sgWabyQVghoEmW9lDLdfpeg==",
+      "version": "14.1.1-canary.17",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.1.1-canary.17.tgz",
+      "integrity": "sha512-I+65TWGo/0jhMVAyInESaA7lbxTv+jzhm5dYpzE6o3ZE+c45dB1/lBiqKehrARcgIBN/d/RzcAMI0htkMEV/1g==",
       "dependencies": {
-        "@next/env": "14.1.1-canary.4",
+        "@next/env": "14.1.1-canary.17",
         "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -9972,15 +9972,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.1.1-canary.4",
-        "@next/swc-darwin-x64": "14.1.1-canary.4",
-        "@next/swc-linux-arm64-gnu": "14.1.1-canary.4",
-        "@next/swc-linux-arm64-musl": "14.1.1-canary.4",
-        "@next/swc-linux-x64-gnu": "14.1.1-canary.4",
-        "@next/swc-linux-x64-musl": "14.1.1-canary.4",
-        "@next/swc-win32-arm64-msvc": "14.1.1-canary.4",
-        "@next/swc-win32-ia32-msvc": "14.1.1-canary.4",
-        "@next/swc-win32-x64-msvc": "14.1.1-canary.4"
+        "@next/swc-darwin-arm64": "14.1.1-canary.17",
+        "@next/swc-darwin-x64": "14.1.1-canary.17",
+        "@next/swc-linux-arm64-gnu": "14.1.1-canary.17",
+        "@next/swc-linux-arm64-musl": "14.1.1-canary.17",
+        "@next/swc-linux-x64-gnu": "14.1.1-canary.17",
+        "@next/swc-linux-x64-musl": "14.1.1-canary.17",
+        "@next/swc-win32-arm64-msvc": "14.1.1-canary.17",
+        "@next/swc-win32-ia32-msvc": "14.1.1-canary.17",
+        "@next/swc-win32-x64-msvc": "14.1.1-canary.17"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "hexoid": "^1.0.0",
     "image-resize-compress": "^1.1.0",
     "isomorphic-dompurify": "^1.8.0",
-    "next": "^14.1.1-canary.4",
+    "next": "^14.1.1-canary.17",
     "next13-progressbar": "^1.1.3",
     "panda-wallet-provider": "^2.3.1",
     "plaiceholder": "^3.0.0",


### PR DESCRIPTION
Fixes this error with anon posting:
```
 TypeError: Cannot redefine property: $$id
    at Function.defineProperties (<anonymous>)
    at eval (./app/components/actions/anon-post-server-action.tsx:100:81)
    at (action-browser)/./app/components/actions/anon-post-server-action.tsx (/Users/remjx/workspace/bitcoin/hodlocker/.next/server/app/(home)/@trending/page.js:1085:1)
    at Function.__webpack_require__ (/Users/remjx/workspace/bitcoin/hodlocker/.next/server/webpack-runtime.js:33:43)
```