### PR TITLE
add github corner icon on large screens

### DIFF
--- a/app/components/navbar/GithubCorner.tsx
+++ b/app/components/navbar/GithubCorner.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import GitHubCorners from '@uiw/react-github-corners';
+
+export default function GithubCorner() {
+    return (
+        <GitHubCorners
+            position="right"
+            href="https://github.com/zer0dt/hodlocker"
+        />
+    )
+}

--- a/app/components/navbar/NavBar.tsx
+++ b/app/components/navbar/NavBar.tsx
@@ -3,11 +3,14 @@ import { Alumni_Sans } from 'next/font/google'
 
 import React, { Suspense } from 'react';
 import Link from 'next/link'
+import dynamic from 'next/dynamic';
 
 import BitcoinLocked from './BitcoinLocked'
 import UserBalance from './UserBalance';
 import { SiBitcoinsv } from 'react-icons/si';
-
+const GithubCorner = dynamic(() => import('./GithubCorner'), {
+  ssr: false,
+});
 
 const inter = Alumni_Sans({ subsets: ['latin'] })
 
@@ -44,6 +47,9 @@ export default async function NavBar() {
           <div className="flex-1 flex justify-end items-center md:order-2 md:pt-2 lg:mr-36">
             <UserBalance />
           </div>
+        </div>
+        <div className="hidden lg:block">
+          <GithubCorner />
         </div>
       </nav>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "20.5.6",
         "@types/react": "18.2.21",
         "@types/react-dom": "18.2.7",
+        "@uiw/react-github-corners": "^1.5.16",
         "@vercel/analytics": "^1.0.2",
         "autoprefixer": "^10.4.15",
         "axios": "^1.6.2",
@@ -4576,6 +4577,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uiw/github-corners": {
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/@uiw/github-corners/-/github-corners-1.5.16.tgz",
+      "integrity": "sha512-XelD5IePslpUBvT0S9jsIGKnnxSkqs6peZH2+rh42x+N1cQ0eQMbTfeWPbJtl4TiZEawywZclXlt55+Ur4CFVA=="
+    },
+    "node_modules/@uiw/react-github-corners": {
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/@uiw/react-github-corners/-/react-github-corners-1.5.16.tgz",
+      "integrity": "sha512-t2oWv3Pboxuy03OVcn13kuQit1X+AUYqP+NhhDlCZmIUZKoRSMeB7IOQo4FBVvRbPO0teOnDDid7xaWAtVsugg==",
+      "dependencies": {
+        "@uiw/github-corners": "1.5.16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/node": "20.5.6",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
+    "@uiw/react-github-corners": "^1.5.16",
     "@vercel/analytics": "^1.0.2",
     "autoprefixer": "^10.4.15",
     "axios": "^1.6.2",


### PR DESCRIPTION
> 1024px width: 
<img width="926" alt="image" src="https://github.com/zer0dt/hodlocker/assets/35121685/55af36e3-5b9f-441d-9543-0581431d95de">

< 1024px width (unchanged): 
<img width="923" alt="image" src="https://github.com/zer0dt/hodlocker/assets/35121685/960576f9-4fea-49bc-b7e6-6e42b4ce9917">

The react library uses global `document` object which doesn't exist on server side for SSR which is why dynamic import and `'use client'` directive is needed. As an optimization we can remove this library and insert SVG directly to use SSR, so this is a quick and dirty implementation, but I think is good for now. 