### PR TITLE
post feed styling

### DIFF
--- a/app/(home)/@latest/page.tsx
+++ b/app/(home)/@latest/page.tsx
@@ -6,7 +6,7 @@ import { postLockLike } from "@/app/server-actions";
 import prisma from "@/app/db";
 import PostComponent from "@/app/components/posts/PostComponent";
 import Pagination from "@/app/components/feeds/sorting-utils/Pagination";
-
+import PostFeedContainer from "@/app/components/feeds/PostFeedContainer";
 
 export const getLatestPosts = cache(
     async (
@@ -173,7 +173,7 @@ export default async function LatestFeed({ searchParams }: LatestFeedProps) {
         const latestPosts = await getLatestPosts(activeSort, activeFilter, currentPage, 30)
 
         return (
-            <div className="grid grid-cols-1 gap-0 w-full lg:w-96">
+            <PostFeedContainer>
                 {
                     latestPosts.map((transaction) => (
                         <PostComponent
@@ -184,7 +184,7 @@ export default async function LatestFeed({ searchParams }: LatestFeedProps) {
                     ))
                 }
                 <Pagination tab={activeTab} currentPage={currentPage} sort={activeSort} filter={activeFilter} />
-            </div>
+            </PostFeedContainer>
         )
     } else {
         return (

--- a/app/(home)/@top/page.tsx
+++ b/app/(home)/@top/page.tsx
@@ -4,8 +4,7 @@ import { postLockLike } from '@/app/server-actions'
 import prisma from '@/app/db';
 import PostComponent from '@/app/components/posts/PostComponent';
 import Pagination from '@/app/components/feeds/sorting-utils/Pagination';
-
-
+import PostFeedContainer from "@/app/components/feeds/PostFeedContainer";
 
 const getTopPosts = cache(async (sort: string, filter: number, page: number, limit: number): Promise<[]> => {
     console.log("getting top posts")
@@ -138,7 +137,7 @@ export default async function TopFeed({ searchParams }: TopFeedProps) {
         const topPosts = await getTopPosts(activeSort, activeFilter, currentPage, 30)
 
         return (
-            <div className="grid grid-cols-1 gap-0 w-full lg:w-96">
+            <PostFeedContainer>
                 {
                     topPosts.map((transaction) => (
                         <PostComponent
@@ -149,7 +148,7 @@ export default async function TopFeed({ searchParams }: TopFeedProps) {
                     ))
                 }
                 <Pagination tab={activeTab} currentPage={currentPage} sort={activeSort} filter={activeFilter} />
-            </div>
+            </PostFeedContainer>
         )
 
 

--- a/app/(home)/@trending/page.tsx
+++ b/app/(home)/@trending/page.tsx
@@ -5,6 +5,7 @@ import { fetchCurrentBlockHeight } from '@/app/utils/fetch-current-block-height'
 import { HODLTransactions, postLockLike } from "@/app/server-actions";
 import PostComponent from "@/app/components/posts/PostComponent";
 import Pagination from "@/app/components/feeds/sorting-utils/Pagination";
+import PostFeedContainer from "@/app/components/feeds/PostFeedContainer";
 
 
 function enrichItem(item: HODLTransactions): any {
@@ -187,7 +188,7 @@ export default async function TrendingFeed({ searchParams }: TrendingFeedProps) 
         const trendingPosts = await getTrendingPosts(activeSort, activeFilter, currentPage, 30)
 
         return (
-            <div className="grid grid-cols-1 gap-0 w-full lg:w-96">
+            <PostFeedContainer>
                 {
                     trendingPosts.filter(Boolean).map((item) => {
                         return (
@@ -200,7 +201,7 @@ export default async function TrendingFeed({ searchParams }: TrendingFeedProps) 
                     })
                 }
                 <Pagination tab={activeTab} currentPage={currentPage} sort={activeSort} filter={activeFilter} />
-            </div>
+            </PostFeedContainer>
         )
     } else {
         return (

--- a/app/components/feeds/PostFeedContainer.tsx
+++ b/app/components/feeds/PostFeedContainer.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const PostFeedContainer = ({ children }: { children: React.ReactNode }) => {
+    return (
+        <div className="grid grid-cols-1 gap-0 w-586 mx-5">
+            {children}
+        </div>
+    )
+}
+
+export default PostFeedContainer;

--- a/app/components/posts/PostComponent.tsx
+++ b/app/components/posts/PostComponent.tsx
@@ -50,6 +50,7 @@ function Post({ transaction, postLockLike }: PostProps) {
   const { currentBlockHeight } = useContext(WalletContext)!;
 
   const [isExpanded, setIsExpanded] = useState(false);
+  const MAX_CHARS_PRE_EXPAND = 420;
 
   const [timeSincePost, setTimeSincePost] = useState<string>("");
 
@@ -293,10 +294,10 @@ function Post({ transaction, postLockLike }: PostProps) {
               </Link>
             )}
 
-            {note.length > 280 && !isExpanded ? (
+            {note.length > MAX_CHARS_PRE_EXPAND && !isExpanded ? (
               <div
                 dangerouslySetInnerHTML={{
-                  __html: formatNote(note.slice(0, 280)) + "...",
+                  __html: formatNote(note.slice(0, MAX_CHARS_PRE_EXPAND)) + "...",
                 }}
               ></div>
             ) : (
@@ -312,7 +313,7 @@ function Post({ transaction, postLockLike }: PostProps) {
               )
             )}
 
-            {note.length > 280 && (
+            {note.length > MAX_CHARS_PRE_EXPAND && (
               <div className="flex justify-end pr-2">
                 {" "}
                 {/* Use 'flex justify-end' to move buttons to the right */}
@@ -342,7 +343,7 @@ function Post({ transaction, postLockLike }: PostProps) {
             )}
           </div>
 
-          <div className="flex justify-between mx-2 my-1 relative">
+          <div className="flex justify-between mx-2 my-2 relative">
             <div className="ml-12 flex items-center">
               <LockLikeInteraction
                 postTxid={transaction.txid}
@@ -363,8 +364,8 @@ function Post({ transaction, postLockLike }: PostProps) {
             </div>
 
 
-            <div className="absolute left-56 top-0.5">  {/* Adjust right and top values as needed */}
-              <div onClick={() => setReplyDrawerVisible(!replyDrawerVisible)} className="flex gap-1 mb-1">
+            <div className="top-0.5">  {/* Adjust right and top values as needed */}
+              <div onClick={() => setReplyDrawerVisible(!replyDrawerVisible)} className="flex gap-1 mb-1 cursor-pointer">
                 <FaRegComment className="reply-button mt-1 h-4 w-4" />
                 <span className="text-sm font-medium font-mono">
                   {transaction.totalAmountandLockLikedForReplies
@@ -378,7 +379,7 @@ function Post({ transaction, postLockLike }: PostProps) {
               </div>
             </div>
 
-            <div className="flex gap-2">
+            <div className="mr-12 flex gap-2 cursor-pointer">
               <RWebShare
                 data={{
                   text:

--- a/app/components/posts/PostComponent.tsx
+++ b/app/components/posts/PostComponent.tsx
@@ -343,8 +343,8 @@ function Post({ transaction, postLockLike }: PostProps) {
             )}
           </div>
 
-          <div className="flex justify-between mx-2 my-2 relative">
-            <div className="ml-12 flex items-center">
+          <div className="flex justify-between mx-14 my-2 relative">
+            <div className="flex items-center">
               <LockLikeInteraction
                 postTxid={transaction.txid}
                 replyTxid={undefined}
@@ -379,7 +379,7 @@ function Post({ transaction, postLockLike }: PostProps) {
               </div>
             </div>
 
-            <div className="mr-12 flex gap-2 cursor-pointer">
+            <div className="flex gap-2 cursor-pointer">
               <RWebShare
                 data={{
                   text:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,9 @@ const config: Config = {
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      width: {
+        '586': '586px',
+      }
     },
   },
   


### PR DESCRIPTION
Miscellaneous styling improvements to post feed

- Increase container width to 586px. Current width is too small on desktop and too large on mobile. Value not scientifically chosen but I've read ~600px is optimal for feeds. Extracted container to a component and used in latest/top/trending.
- Increase max characters pre-expand from 280 to 420 (50% increase) to take advantage of larger container.
- Add missing `cursor-pointer` css to post action buttons.
- Improve spacing on post action buttons (space-between with horizontal margin, no absolute positioning of items).