### PR TITLE
post action buttons style and bitcoin amount format

### DIFF
--- a/app/components/posts/LockLikeDrawer.tsx
+++ b/app/components/posts/LockLikeDrawer.tsx
@@ -6,6 +6,7 @@ import { SiBitcoinsv } from "react-icons/si";
 import { HODLTransactions } from "@/app/server-actions";
 
 import { WalletContext } from "../../context/WalletContextProvider";
+import { formatBitcoinValue } from "./posts-format";
 
 interface LockLikes {
   txid: string;
@@ -39,22 +40,6 @@ function timeSinceLike(locklike: LockLikes) {
   }
 }
 
-function formatBitcoinValue(initialPlusLikesTotal: number) {
-  if (initialPlusLikesTotal < 0.001) {
-    return "";
-  } else if (initialPlusLikesTotal < 1) {
-    return initialPlusLikesTotal.toFixed(3);
-  } else if (initialPlusLikesTotal < 10) {
-    return initialPlusLikesTotal.toFixed(3);
-  } else {
-    return (
-      initialPlusLikesTotal.toLocaleString(undefined, {
-        maximumFractionDigits: 3,
-      })
-    );
-  }
-}
-
 const LockLikeDrawer = ({
   transaction
 }: LockLikeDrawerProps) => {
@@ -68,17 +53,16 @@ const LockLikeDrawer = ({
 
   return (
     <>
-      <button
-        data-drawer-body-scrolling="false"
-        onClick={handleLikeDrawerToggle} // Toggle the drawer when this button is clicked
-        className="flex items-center text-black dark:text-white text-sm ml-1 cursor-pointer"
-      >
-        <span className="font-medium font-mono">{formatBitcoinValue(transaction.totalAmountandLockLiked / 100000000)}</span>
-        {(transaction.totalAmountandLockLiked / 100000000) > 0.001 ? (
+      {transaction.totalAmountandLockLiked > 1 ? (
+        <button
+          data-drawer-body-scrolling="false"
+          onClick={handleLikeDrawerToggle} // Toggle the drawer when this button is clicked
+          className="flex items-center text-black dark:text-white text-sm ml-1 cursor-pointer hover:text-orange-400"
+        >
+          <span className="font-medium font-mono">{formatBitcoinValue(transaction.totalAmountandLockLiked / 100000000)}</span>
           <SiBitcoinsv className="text-orange-400 ml-1" />
-        ) : null}
-
-      </button>
+        </button>
+      ) : null}
 
       <div
         id={`drawer-example-${transaction.txid}`} // Unique ID based on transaction.txid

--- a/app/components/posts/PostComponent.tsx
+++ b/app/components/posts/PostComponent.tsx
@@ -84,7 +84,7 @@ export default async function Post({ transaction, postLockLike }: PostProps) {
                 </Suspense>
               </Link>
               <div className="ml-3 flex items-center -mt-4">
-                <div className="text-md text-black dark:text-white font-semibold block leading-tight">
+                <div className="text-md text-black dark:text-white font-semibold block leading-tight hover:text-orange-400">
                   <Link href={"/" + transaction.handle_id}>
                     {transaction.handle_id}
                   </Link>

--- a/app/components/posts/posts-format.ts
+++ b/app/components/posts/posts-format.ts
@@ -1,0 +1,15 @@
+export function formatBitcoinValue(initialPlusLikesTotal: number) {
+    if (initialPlusLikesTotal < 0.001) {
+      return "<.001";
+    } else if (initialPlusLikesTotal < 1) {
+      return initialPlusLikesTotal.toFixed(3);
+    } else if (initialPlusLikesTotal < 10) {
+      return initialPlusLikesTotal.toFixed(3);
+    } else {
+      return (
+        initialPlusLikesTotal.toLocaleString(undefined, {
+          maximumFractionDigits: 3,
+        })
+      );
+    }
+}

--- a/app/components/posts/replies/RepliesDrawer.tsx
+++ b/app/components/posts/replies/RepliesDrawer.tsx
@@ -10,6 +10,7 @@ import { SiBitcoinsv } from "react-icons/si";
 import { HODLTransactions } from "@/app/server-actions";
 
 import { usePathname } from 'next/navigation'
+import { formatBitcoinValue } from "../posts-format";
 
 interface RepliesDrawerProps {
   transaction: any,
@@ -79,11 +80,11 @@ const RepliesDrawer = ({
           }`}>
       </div>
 
-      <div onClick={toggleReplyDrawer} className="flex gap-1 mb-1 cursor-pointer">
-        <FaRegComment className="reply-button mt-1 h-4 w-4 hover:text-orange-400" />
+      <div onClick={toggleReplyDrawer} className="flex items-center gap-1 mb-1 cursor-pointer hover:text-orange-400">
+        <FaRegComment className="reply-button h-4 w-4" />
         <span className="text-sm font-medium font-mono">
           {transaction.totalAmountandLockLikedForReplies
-            ? (transaction.totalAmountandLockLikedForReplies / 100000000).toFixed(2)
+            ? formatBitcoinValue(transaction.totalAmountandLockLikedForReplies / 100000000)
             : null}
         </span>
         {transaction.totalAmountandLockLikedForReplies ? (


### PR DESCRIPTION
- apply orange hover effect to comment icon+amount (previously only icon)
- apply orange hover effect to poster handle
- instead of showing no locks if <.001, show "<.001" to provide better feedback to user on small lock amounts