### PR TITLE
fix app bar wallet click area

### DIFF
--- a/app/components/appbar/AppBar.tsx
+++ b/app/components/appbar/AppBar.tsx
@@ -185,14 +185,12 @@ const AppBar = () => {
             </svg>
             <span className="sr-only">Home</span>
           </button>
-          <button
-            type="button"
+          <Link
+            href={handle ? "/" + handle + "/history/locked" : "#"}
+            scroll={true}
             className="inline-flex flex-col items-center justify-center px-5 hover:bg-gray-50 dark:hover:bg-gray-800 group"
           >
-            <Link
-              href={handle ? "/" + handle + "/history/locked" : "/"}
-              scroll={true}
-            >
+            <button type="button">
               <svg
                 className="w-5 h-5 mb-1 text-gray-500 dark:text-gray-400 group-hover:text-orange-500 dark:group-hover:text-orange-500"
                 aria-hidden="true"
@@ -203,9 +201,9 @@ const AppBar = () => {
                 <path d="M11.074 4 8.442.408A.95.95 0 0 0 7.014.254L2.926 4h8.148ZM9 13v-1a4 4 0 0 1 4-4h6V6a1 1 0 0 0-1-1H1a1 1 0 0 0-1 1v13a1 1 0 0 0 1 1h17a1 1 0 0 0 1-1v-2h-6a4 4 0 0 1-4-4Z" />
                 <path d="M19 10h-6a2 2 0 0 0-2 2v1a2 2 0 0 0 2 2h6a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1Zm-4.5 3.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2ZM12.62 4h2.78L12.539.41a1.086 1.086 0 1 0-1.7 1.352L12.62 4Z" />
               </svg>
-            </Link>
-            <span className="sr-only">Wallet</span>
-          </button>
+              <span className="sr-only">Wallet</span>
+            </button>
+          </Link>
           <div className="flex items-center justify-center">
             <button
               onClick={() => setIsDrawerVisible(!isDrawerVisible)}


### PR DESCRIPTION
Closes #11 

- Wrap entire button with link instead of only icon
- If user not logged in, do nothing by navigating to "#" (empty anchor) instead of "/" (home)