### PR TITLE
replace relayx connect modal with generic connect modal throughout app

### DIFF
--- a/app/components/actions/LockLikeInteraction.tsx
+++ b/app/components/actions/LockLikeInteraction.tsx
@@ -26,7 +26,7 @@ interface LockLikeInteractionProps {
 }
 
 export default function LockLikeInteraction({ postTxid, replyTxid, postLockLike }: LockLikeInteractionProps) {    
-    const { currentBlockHeight, pubkey, fetchRelayOneData, handle, isLinked, bitcoinerSettings } = useContext(WalletContext)!;
+    const { currentBlockHeight, pubkey, fetchRelayOneData, handle, isLinked, bitcoinerSettings, setSignInModalVisible } = useContext(WalletContext)!;
 
     const router = useRouter()
 
@@ -160,7 +160,7 @@ export default function LockLikeInteraction({ postTxid, replyTxid, postLockLike 
         }  
       } else {
         setLoading(false)
-        await fetchRelayOneData()
+        setSignInModalVisible(true)
         return
       }     
     }

--- a/app/components/actions/ReplyInteraction.tsx
+++ b/app/components/actions/ReplyInteraction.tsx
@@ -26,7 +26,7 @@ interface deployProps {
 export default function replyInteraction({ transaction }: deployProps) {
   const router = useRouter();
 
-  const { handle, paymail, pubkey, isLinked, fetchRelayOneData, currentBlockHeight } = useContext(WalletContext)!;
+  const { handle, paymail, pubkey, isLinked, fetchRelayOneData, currentBlockHeight, setSignInModalVisible } = useContext(WalletContext)!;
 
   const [loading, setLoading] = useState(false)
   const [paying, setPaying] = useState(false)
@@ -222,6 +222,7 @@ export default function replyInteraction({ transaction }: deployProps) {
     } else {
       setPaying(false)
       setLoading(false)
+      setSignInModalVisible(true)
     }
   }
 

--- a/app/components/actions/deployNFTPost-(not-used).tsx
+++ b/app/components/actions/deployNFTPost-(not-used).tsx
@@ -47,6 +47,7 @@ export default function DeployNFTPost({
     isLinked,
     fetchRelayOneData,
     currentBlockHeight,
+    setSignInModalVisible,
   } = useContext(WalletContext)!;
   
   const [darkMode, setDarkMode] = useState(false)
@@ -238,7 +239,7 @@ export default function DeployNFTPost({
       }
     } else {
       setLoading(false);
-      await fetchRelayOneData();
+      setSignInModalVisible(true)
       return;
     }
   };

--- a/app/components/actions/deployPost.tsx
+++ b/app/components/actions/deployPost.tsx
@@ -47,6 +47,7 @@ export default function DeployInteraction({
     isLinked,
     fetchRelayOneData,
     currentBlockHeight,
+    setSignInModalVisible,
   } = useContext(WalletContext)!;
 
   const [darkMode, setDarkMode] = useState(false);
@@ -305,7 +306,7 @@ export default function DeployInteraction({
       }
     } else {
       setLoading(false);
-      await fetchRelayOneData();
+      setSignInModalVisible(true);
       return;
     }
   };

--- a/app/components/appbar/AppBar.tsx
+++ b/app/components/appbar/AppBar.tsx
@@ -37,7 +37,7 @@ interface NewNotifications {
 }
 
 const AppBar = () => {
-  const { fetchRelayOneData, handle, currentBlockHeight } = useContext(WalletContext)!;
+  const { fetchRelayOneData, handle, currentBlockHeight, signInModalVisible, setSignInModalVisible } = useContext(WalletContext)!;
 
   const router = useRouter();
   const pathname = usePathname();
@@ -49,7 +49,6 @@ const AppBar = () => {
 
   const dropdownRef = useRef(null);
 
-  const [signInModalVisible, setSignInModalVisible] = useState(false);
   const [profileDropdownVisible, setProfileDropdownVisible] = useState(false);
 
   const [settingsModalVisible, setSettingsModalVisible] = useState(false);

--- a/app/context/WalletContextProvider.tsx
+++ b/app/context/WalletContextProvider.tsx
@@ -46,6 +46,8 @@ interface WalletContextType {
   bitcoinerSettings: BitcoinerSettings | undefined,
   setBitcoinerSettings: React.Dispatch<React.SetStateAction<BitcoinerSettings | undefined>>,
   currentBlockHeight: number | undefined,
+  signInModalVisible: boolean,
+  setSignInModalVisible: React.Dispatch<React.SetStateAction<boolean>>,
 }
 
 
@@ -71,6 +73,7 @@ export const WalletContextProvider = ({
   const [bitcoinerSettings, setBitcoinerSettings] = useState<BitcoinerSettings | undefined>(undefined)
   const [isLinked, setIsLinked] = useState<boolean | undefined>(undefined)
   const [currentBlockHeight, setCurrentBlockHeight] = useState<number | undefined>(undefined)
+  const [signInModalVisible, setSignInModalVisible] = useState(false);
 
 
 
@@ -139,7 +142,7 @@ export const WalletContextProvider = ({
   return (
     <>
       <Script src="https://one.relayx.io/relayone.js" onLoad={() => checkIfLinked()} />
-      <WalletContext.Provider value={{ fetchRelayOneData, pubkey, handle, userBalance, paymail, isLinked, bitcoinerSettings, setBitcoinerSettings, currentBlockHeight }}>
+      <WalletContext.Provider value={{ fetchRelayOneData, pubkey, handle, userBalance, paymail, isLinked, bitcoinerSettings, setBitcoinerSettings, currentBlockHeight, signInModalVisible, setSignInModalVisible }}>
         {children}
       </WalletContext.Provider>
     </>


### PR DESCRIPTION
For a consistent login experience,
- moved `signInModalVisible` state from AppBar to WalletContext
- trigger `setSignInModalVisible()` everywhere where `fetchRelayOneData()` was used to trigger login