### PR TITLE
fix default locklike input format

### DIFF
--- a/app/components/actions/LockLikeInteraction.tsx
+++ b/app/components/actions/LockLikeInteraction.tsx
@@ -32,7 +32,7 @@ export default function LockLikeInteraction({ postTxid, replyTxid, postLockLike 
     const router = useRouter()
 
     const [blocksToLock, setBlocksToLock] = useState(DEFAULT_LOCKLIKE_BLOCKS.toString())
-    const [amountToLock, setAmountToLock] = useState(DEFAULT_LOCKLIKE_AMOUNT.toFixed(8))
+    const [amountToLock, setAmountToLock] = useState(DEFAULT_LOCKLIKE_AMOUNT.toString())
 
     const [loading, setLoading] = useState(false)
 

--- a/app/components/actions/deployPost.tsx
+++ b/app/components/actions/deployPost.tsx
@@ -68,7 +68,7 @@ export default function DeployInteraction({
   const amountToLock = DEFAULT_DEPLOY_POST_AMOUNT.toString()
   const blocksToLock = DEFAULT_DEPLOY_POST_BLOCKS
   const [addLockLike, setAddLockLike] = useState(false)
-  const [amountToLockLike, setAmountToLockLike] = useState<string>(DEFAULT_LOCKLIKE_AMOUNT.toFixed(8));
+  const [amountToLockLike, setAmountToLockLike] = useState<string>(DEFAULT_LOCKLIKE_AMOUNT.toString());
   const [blocksToLockLike, setBlocksToLockLike] = useState<number>(DEFAULT_LOCKLIKE_BLOCKS);
 
   const [uploadedImage, setUploadedImage] = useState<string | null>(null);
@@ -115,8 +115,8 @@ export default function DeployInteraction({
       setAmountToLockLike(bitcoinerSettings.amountToLock.toString());
       setBlocksToLockLike(bitcoinerSettings.blocksToLock);
     } else {
-      setAmountToLockLike(DEFAULT_DEPLOY_POST_AMOUNT.toFixed(8));
-      setBlocksToLockLike(DEFAULT_DEPLOY_POST_BLOCKS);
+      setAmountToLockLike(DEFAULT_LOCKLIKE_AMOUNT.toString());
+      setBlocksToLockLike(DEFAULT_LOCKLIKE_BLOCKS);
     }
   }, [bitcoinerSettings]);
 


### PR DESCRIPTION
fixes bug introduced in LockInput component PR:
- currently default lock amount displays as "0.01000000", this fixes it back to "0.01"
- currently uses default deploy amount for default add lock amount, fixes it to default locklike amount